### PR TITLE
Remove drawn tiles from future draws

### DIFF
--- a/PrizeDraw/MainWindow.xaml.cs
+++ b/PrizeDraw/MainWindow.xaml.cs
@@ -135,6 +135,7 @@ namespace PrizeDraw
                 case Key.B:
                 {
                     _viewModel.Restart();
+                    _viewModel.Tiles.Remove(_viewModel.SelectedTile);
 
                     while (Canvas.Children.Count > 0)
                     {


### PR DESCRIPTION
Removing the selected tile from the tiles collection prevents it from being redrawn in subsequent draws without needing to redraw the grid